### PR TITLE
Zip Codes Validation

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -8,7 +8,7 @@ class Address < ApplicationRecord
   # HACK: Only save upcase state abbr name
   validates :state,     presence: true, length: { is: 2 }
   # HACK: The RegEx validation is needed to be refactored
-  validates :zip_code,  presence: true, format: { with: /\A9[0-6]\d{3}\z/ }
+  validates :zip_code,  presence: true, format: { with: /\A[0-9]{5}(?:-[0-9]{4})?\z/ }
 
   private
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -36,19 +36,22 @@ RSpec.describe Address do
 
   context 'zip code' do
     it 'should be valid with these zip codes' do
-      %w[90001 90403 96054].each do |zcode|
+      %w[90000 96054 37112 99999 54221-4366 90210-7321].each do |zcode|
         address.zip_code = zcode
         expect(address).to be_valid
       end
     end
 
-    # BUG:
-    #   "90000" and "90655" returns validation error. Check out the RegEx
-    # it 'should not be valid with there zip codes'
-
     it 'should not be valid with letters' do
       address.zip_code = 'SaMo3'
       expect(address).to_not be_valid
+    end
+
+    it 'should not be valid with an improper seperator' do
+      ['12342 - 5462', '56331 -5672', '46621- 3677', '23456_1944'].each do |zcode|
+        address.zip_code = zcode
+        expect(address).to_not be_valid
+      end
     end
   end
 


### PR DESCRIPTION
### Refactor of regex pattern to validate zip code on Address model

Previously the zip code validation used a California specific regex pattern to validate the zip code. This 
is problematic as the state validation on the address model implies that a user can enter their address from any location in the US. This refactored regex pattern is also more robust, fixing the flakey specs mentioned in the comments of the address_spec. 

I added more specs and expanded the existing cases to test the more liberal regex pattern.

Fixes #36