### PR TITLE
Extend spec coverage for models

### DIFF
--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -11,7 +11,8 @@ class House < ApplicationRecord
 
   validates :rent,             presence: true,
                                numericality: { greater_than: 0 }
-  validates :deposit,          numericality: { greater_than: 0 }
+  validates :deposit,          allow_nil: true,
+                               numericality: { greater_than: 0 }
   validates :preferred_gender, presence: true, inclusion: { in: 0..2 }
   validates :available_at,     presence: true, at_future: true
 

--- a/lib/validators/at_future_validator.rb
+++ b/lib/validators/at_future_validator.rb
@@ -1,6 +1,6 @@
 class AtFutureValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    if attribute.present? && value &. present? && value < Time.zone.today
+    if attribute.present? && value&.present? && value < Time.zone.today
       object.errors[attribute] << (options[:message] || 'must be in the future')
     end
   end

--- a/lib/validators/at_future_validator.rb
+++ b/lib/validators/at_future_validator.rb
@@ -1,6 +1,6 @@
 class AtFutureValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    if attribute.present? && value.present? && value < Time.zone.today
+    if attribute.present? && value &. present? && value < Time.zone.today
       object.errors[attribute] << (options[:message] || 'must be in the future')
     end
   end

--- a/lib/validators/at_future_validator.rb
+++ b/lib/validators/at_future_validator.rb
@@ -1,6 +1,6 @@
 class AtFutureValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    if attribute.present? && value < Time.zone.today
+    if attribute.present? && value.present? && value < Time.zone.today
       object.errors[attribute] << (options[:message] || 'must be in the future')
     end
   end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,16 +3,16 @@ require 'rails_helper'
 RSpec.describe Address do
   subject(:address) { create(:address, house: build(:house)) }
 
-  it 'should be valid' do
+  it 'is valid' do
     is_expected.to be_valid
   end
 
-  it 'should be valid without second address field' do
+  it 'is valid without second address field' do
     address.address_2 = nil
     is_expected.to be_valid
   end
 
-  context 'should not be valid without' do
+  context 'is not valid without' do
     it 'first address field' do
       address.address_1 = nil
       is_expected.to_not be_valid
@@ -35,19 +35,19 @@ RSpec.describe Address do
   end
 
   context 'zip code' do
-    it 'should be valid with these zip codes' do
+    it 'is valid with these zip codes' do
       %w[90000 96054 37112 99999 54221-4366 90210-7321].each do |zcode|
         address.zip_code = zcode
         is_expected.to be_valid
       end
     end
 
-    it 'should not be valid with letters' do
+    it 'is not valid with letters' do
       address.zip_code = 'SaMo3'
       is_expected.to_not be_valid
     end
 
-    it 'should not be valid with an improper seperator' do
+    it 'is not valid with an improper seperator' do
       ['12342 - 5462', '56331 -5672', '46621- 3677', '23456_1944'].each do |zcode|
         address.zip_code = zcode
         is_expected.to_not be_valid
@@ -56,17 +56,17 @@ RSpec.describe Address do
   end
 
   context 'state' do
-    it 'should be valid which it has only 2 chars' do
+    it 'is valid with 2 chars' do
       address.state = 'CA'
       is_expected.to be_valid
     end
 
-    it 'should not be valid which it does not have only 2 chars' do
+    it 'is not valid with more than 2 chars' do
       address.state = 'WSH'
       is_expected.to_not be_valid
     end
 
-    it 'should be capitiliazed after save' do
+    it 'is capitiliazed after save' do
       state_name = 'ca'
 
       @address = create(:address, state: state_name, house: build(:house))

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,36 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe Address do
-  let(:address) { create(:address, house: build(:house)) }
+  subject(:address) { create(:address, house: build(:house)) }
 
   it 'should be valid' do
-    expect(address).to be_valid
+    is_expected.to be_valid
   end
 
   it 'should be valid without second address field' do
     address.address_2 = nil
-    expect(address).to be_valid
+    is_expected.to be_valid
   end
 
   context 'should not be valid without' do
     it 'first address field' do
       address.address_1 = nil
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'city' do
       address.city = nil
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'state' do
       address.state = nil
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'zip_code' do
       address.zip_code = nil
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
   end
 
@@ -38,19 +38,19 @@ RSpec.describe Address do
     it 'should be valid with these zip codes' do
       %w[90000 96054 37112 99999 54221-4366 90210-7321].each do |zcode|
         address.zip_code = zcode
-        expect(address).to be_valid
+        is_expected.to be_valid
       end
     end
 
     it 'should not be valid with letters' do
       address.zip_code = 'SaMo3'
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'should not be valid with an improper seperator' do
       ['12342 - 5462', '56331 -5672', '46621- 3677', '23456_1944'].each do |zcode|
         address.zip_code = zcode
-        expect(address).to_not be_valid
+        is_expected.to_not be_valid
       end
     end
   end
@@ -58,12 +58,12 @@ RSpec.describe Address do
   context 'state' do
     it 'should be valid which it has only 2 chars' do
       address.state = 'CA'
-      expect(address).to be_valid
+      is_expected.to be_valid
     end
 
     it 'should not be valid which it does not have only 2 chars' do
       address.state = 'WSH'
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'should be capitiliazed after save' do
@@ -75,7 +75,7 @@ RSpec.describe Address do
 
     it 'can not be integer' do
       address.state = 3
-      expect(address).to_not be_valid
+      is_expected.to_not be_valid
     end
   end
 end

--- a/spec/models/checkbox_spec.rb
+++ b/spec/models/checkbox_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Checkbox do
-  let(:checkbox) { create(:checkbox, house: build(:house)) }
+  subject(:checkbox) { create(:checkbox, house: build(:house)) }
 
   it 'should be valid' do
-    expect(checkbox).to be_valid
+    is_expected.to be_valid
   end
 
   # All of them true because of the beautiy of Active Record <3
@@ -12,7 +12,7 @@ RSpec.describe Checkbox do
   ['true', 1, nil].each do |lol|
     it "should not be valid if it has #{lol}" do
       checkbox.air_conditioning = lol
-      expect(checkbox).to be_valid
+      is_expected.to be_valid
     end
   end
 end

--- a/spec/models/checkbox_spec.rb
+++ b/spec/models/checkbox_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Checkbox do
   # AR returns to true them except the +nil+.
   ['true', 1, nil].each do |lol|
     it "should not be valid if it has #{lol}" do
-      checkbox.air_conditioning = lol
+      checkbox.air_conditioning = false
       expect(checkbox).to be_valid
     end
   end

--- a/spec/models/checkbox_spec.rb
+++ b/spec/models/checkbox_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe Checkbox do
   subject(:checkbox) { create(:checkbox, house: build(:house)) }
 
-  it 'should be valid' do
+  it 'is valid' do
     is_expected.to be_valid
   end
 
   # All of them true because of the beautiy of Active Record <3
   # AR returns to true them except the +nil+.
   ['true', 1, nil].each do |lol|
-    it "should not be valid if it has #{lol}" do
+    it "is not valid if it has #{lol}" do
       checkbox.air_conditioning = lol
       is_expected.to be_valid
     end

--- a/spec/models/checkbox_spec.rb
+++ b/spec/models/checkbox_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Checkbox do
   # AR returns to true them except the +nil+.
   ['true', 1, nil].each do |lol|
     it "should not be valid if it has #{lol}" do
-      checkbox.air_conditioning = false
+      checkbox.air_conditioning = lol
       expect(checkbox).to be_valid
     end
   end

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'byebug'
 
 RSpec.describe House do
   let(:house) { create(:house, :either) }
@@ -92,6 +93,11 @@ RSpec.describe House do
     it 'is valid if time is future' do
       house.available_at = 1.week.after
       expect(house).to be_valid
+    end
+
+    it 'is not valid without' do
+      house.available_at = nil
+      expect(house).not_to be_valid
     end
   end
 end

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -30,14 +30,6 @@ RSpec.describe House do
   end
 
   context 'deposit' do
-    # BUG:
-    #   1) House deposit is valid without
-    #     Failure/Error: expect(house).to be_valid
-    #       expected #<House id: 220, rent: 850, deposit: nil,
-    #   description: "Lorem ipsum dolor sit amet", preferred_gender: 0,
-    #   created_at: "2018-08-13 06:42:25", updated_at: "2018-08-13 06:42:25">
-    #   to be valid, but got errors: Deposit is not a number
-    #
     it 'is valid with' do
       house.deposit = 999
       expect(house).to be_valid
@@ -53,10 +45,10 @@ RSpec.describe House do
       expect(house).not_to be_valid
     end
 
-    # XXX:
-    #   ActiveRecord or something returns string to zero.
-    #
-    # it "can not be string"
+    it 'can not be a string' do
+      house.deposit = 'lots'
+      expect(house).not_to be_valid
+    end
 
     it 'can not be zero' do
       house.deposit = 0

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe House do
     end
 
     it 'is not an included preferred gender' do
+      house.preferred_gender = 3
+      expect(house).not_to be_valid
+    end
+
+    it 'is an included preferred gender' do
       house.preferred_gender = 2
       expect(house).to be_valid
     end

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -18,18 +18,10 @@ RSpec.describe House do
       expect(house).not_to be_valid
     end
 
-    # BUG:
-    #   1) House rent can not be string
-    #      Failure/Error: expect(house).to_not be_valid
-    #        expected #<House id: 198, rent: 0.83e3, deposit: 600,
-    #   description: "Lorem ipsum dolor sit amet", preferred_gender: 0,
-    #   created_at: "2018-08-13 06:37:56", updated_at: "2018-08-13 06:37:56">
-    #   not to be valid
-    #
-    # it "can not be string"  do
-    #   house.rent = "830"
-    #   expect(house).to_not be_valid
-    # end
+    it 'can not be string'  do
+      house.rent = 'three hundred'
+      expect(house).to_not be_valid
+    end
 
     it 'can not be zero' do
       house.rent = 0
@@ -46,10 +38,15 @@ RSpec.describe House do
     #   created_at: "2018-08-13 06:42:25", updated_at: "2018-08-13 06:42:25">
     #   to be valid, but got errors: Deposit is not a number
     #
-    # it "is valid without" do
-    #   house.deposit = nil
-    #   expect(house).to be_valid
-    # end
+    it 'is valid with' do
+      house.deposit = 999
+      expect(house).to be_valid
+    end
+
+    it 'is valid without' do
+      house.deposit = nil
+      expect(house).to be_valid
+    end
 
     it 'can not be negative' do
       house.deposit = -1
@@ -73,6 +70,10 @@ RSpec.describe House do
       expect(house).not_to be_valid
     end
 
+    it 'is not an included preferred gender' do
+      house.preferred_gender = 2
+      expect(house).to be_valid
+    end
     # XXX:
     #   ActiveRecord or something returns string to zero.
     #

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'byebug'
 
 RSpec.describe House do
   subject(:house) { create(:house, :either) }

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -2,75 +2,75 @@ require 'rails_helper'
 require 'byebug'
 
 RSpec.describe House do
-  let(:house) { create(:house, :either) }
+  subject(:house) { create(:house, :either) }
 
   it 'is valid' do
-    expect(house).to be_valid
+    is_expected.to be_valid
   end
 
   context 'rent' do
     it 'is not valid without' do
       house.rent = nil
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'can not be negative' do
       house.rent = -1
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'can not be string'  do
       house.rent = 'three hundred'
-      expect(house).to_not be_valid
+      is_expected.to_not be_valid
     end
 
     it 'can not be zero' do
       house.rent = 0
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
   end
 
   context 'deposit' do
     it 'is valid with' do
       house.deposit = 999
-      expect(house).to be_valid
+      is_expected.to be_valid
     end
 
     it 'is valid without' do
       house.deposit = nil
-      expect(house).to be_valid
+      is_expected.to be_valid
     end
 
     it 'can not be negative' do
       house.deposit = -1
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'can not be a string' do
       house.deposit = 'lots'
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'can not be zero' do
       house.deposit = 0
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
   end
 
   context 'preferred gender' do
     it 'is not valid without' do
       house.preferred_gender = nil
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'is not an included preferred gender' do
       house.preferred_gender = 3
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'is an included preferred gender' do
       house.preferred_gender = 2
-      expect(house).to be_valid
+      is_expected.to be_valid
     end
     # XXX:
     #   ActiveRecord or something returns string to zero.
@@ -82,22 +82,22 @@ RSpec.describe House do
   context 'available at' do
     it 'is not valid if time is past' do
       house.available_at = 1.week.ago
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
 
     it 'is valid if time is today' do
       house.available_at = Time.zone.today
-      expect(house).to be_valid
+      is_expected.to be_valid
     end
 
     it 'is valid if time is future' do
       house.available_at = 1.week.after
-      expect(house).to be_valid
+      is_expected.to be_valid
     end
 
     it 'is not valid without' do
       house.available_at = nil
-      expect(house).not_to be_valid
+      is_expected.not_to be_valid
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  it 'should have many houses' do
+  it 'has many houses' do
     t = User.reflect_on_association(:houses)
     expect(t.macro).to eq(:has_many)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe User do
+  it 'should have many houses' do
+    t = User.reflect_on_association(:houses)
+    expect(t.macro).to eq(:has_many)
+  end
 end


### PR DESCRIPTION
In this pull request, I have added several more specs for the models. Please note that there is more coverage to go. Hopefully this will lay a good foundation. 

I also fixed a few spec bugs that were mentioned in the comments. For example, allowing a deposit of nil. There still remains a few bugs, specifically when expecting string to return in in valid model. 

I will close issue #26 when I make another pull request for controller specs
