### PR TITLE
Add sentry raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ group :production do
   # Use Redis adapter to run Action Cable in production
   gem 'redis', '~> 4.0'
   gem 'sidekiq', '~> 5.2.1'
+
+  gem 'sentry-raven'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     foundation_emails (2.2.1.0)
     geocoder (1.5.0)
@@ -124,6 +126,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
@@ -232,6 +235,8 @@ GEM
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     sidekiq (5.2.2)
@@ -304,6 +309,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 5.0)
   scss_lint (~> 0.57.0)
+  sentry-raven
   shoulda-matchers
   sidekiq (~> 5.2.1)
   spring

--- a/app.json
+++ b/app.json
@@ -1,0 +1,36 @@
+{
+  "name": "Mağara",
+  "description": "Off-campus housing web application for universities and colleges.",
+  "scripts": {
+    "postdeploy": "bin/setup"
+  },
+  "env": {
+    "MAGARA_DOMAIN": {
+      "required": true
+    },
+    "SENTRY_DSN": {
+      "required": true
+    },
+    "RAILS_ENV": "production",
+    "RAILS_LOG_TO_STDOUT": "enabled",
+    "RAILS_SERVE_STATIC_FILES": "enabled"
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "heroku-postgresql",
+    "heroku-redis",
+    "sendgrid"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds Sentry SDK and `app.json` for Heroku App Review. Sentry requires `SENTRY_DSN`, so you need to add as an environment variable on production environment. Development and test environments don't need `SENTRY_DSN`.