### PR TITLE
:sparkles: refactor at_future_validator

### DIFF
--- a/app/validators/at_future_validator.rb
+++ b/app/validators/at_future_validator.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
+##
+# This validator validates future date. If the date is in future, does nothing.
+# However, if not, adds a record error as must be in the future. This function
+# does NOT work the other way around. Also, worth to mention, this function
+# only works with date; not time or date+time.
+#
+# == Example
+#
+#   class Person < ApplicationRecord
+#     attr_accessor :birth_day
+#
+#     validates :birth_day, at_future: true
+#   end
+
 class AtFutureValidator < ActiveModel::EachValidator
-  def validate_each(object, attribute, value)
-    if attribute.present? && value&.present? && value < Time.zone.today
-      object.errors[attribute] << (options[:message] || 'must be in the future')
+  def validate_each(record, attribute, value)
+    if value&.present? && value < Date.current
+      record.errors.add attribute, 'must be in the future'
     end
   end
 end

--- a/spec/validators/at_future_validator_spec.rb
+++ b/spec/validators/at_future_validator_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe AtFutureValidator do
+  subject do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :date
+
+      validates :date, at_future: true
+    end.new
+  end
+
+  context "when date is yesterday" do
+    it "is not valid" do
+      subject.date = Date.yesterday
+      subject.validate
+
+      expect(subject.errors[:date]).to include 'must be in the future'
+    end
+  end
+
+  context "when date is tomorrow" do
+    it "is valid" do
+      subject.date = Date.tomorrow
+      subject.validate
+
+      expect(subject.errors[:date]).to_not include 'must be in the future'
+    end
+  end
+end

--- a/spec/validators/at_future_validator_spec.rb
+++ b/spec/validators/at_future_validator_spec.rb
@@ -1,7 +1,9 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 RSpec.describe AtFutureValidator do
-  subject do
+  subject(:house) do
     Class.new do
       include ActiveModel::Validations
       attr_accessor :date
@@ -10,21 +12,21 @@ RSpec.describe AtFutureValidator do
     end.new
   end
 
-  context "when date is yesterday" do
-    it "is not valid" do
-      subject.date = Date.yesterday
-      subject.validate
+  context 'when date is yesterday' do
+    it 'is not valid' do
+      house.date = Date.yesterday
+      house.validate
 
-      expect(subject.errors[:date]).to include 'must be in the future'
+      expect(house.errors[:date]).to include 'must be in the future'
     end
   end
 
-  context "when date is tomorrow" do
-    it "is valid" do
-      subject.date = Date.tomorrow
-      subject.validate
+  context 'when date is tomorrow' do
+    it 'is valid' do
+      house.date = Date.tomorrow
+      house.validate
 
-      expect(subject.errors[:date]).to_not include 'must be in the future'
+      expect(house.errors[:date]).not_to include 'must be in the future'
     end
   end
 end


### PR DESCRIPTION
This PR proves the stability of `at_future_validator` to validate future dates with refactoring and adding RSpec test for it.